### PR TITLE
feat(Chatwoot): pagination params for list endpoints (v2)

### DIFF
--- a/nodes/Chatwoot/Chatwoot.node.test.ts
+++ b/nodes/Chatwoot/Chatwoot.node.test.ts
@@ -1,0 +1,493 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Chatwoot } from './Chatwoot.node';
+
+// Mock the n8n-workflow module
+vi.mock('n8n-workflow', () => ({
+  NodeOperationError: class extends Error {
+    constructor(node: any, error: Error | string, options?: any) {
+      const message = typeof error === 'string' ? error : error.message;
+      super(message);
+      this.name = 'NodeOperationError';
+    }
+  }
+}));
+
+describe('Chatwoot Node - Business Logic Tests', () => {
+  let chatwoot: Chatwoot;
+  let mockExecuteFunctions: any;
+
+  beforeEach(() => {
+    chatwoot = new Chatwoot();
+    mockExecuteFunctions = {
+      getInputData: vi.fn(() => [{ json: { test: 'data' } }]),
+      getNodeParameter: vi.fn(),
+      getNode: vi.fn(() => ({ name: 'Test Chatwoot Node' })),
+      continueOnFail: vi.fn(() => false),
+      helpers: {
+        request: vi.fn()
+      }
+    };
+  });
+
+  describe('Contact Operations', () => {
+    describe('Get Contacts', () => {
+      it('should successfully retrieve all contacts', async () => {
+        const mockResponse = {
+          payload: [
+            { id: 1, name: 'John Doe', email: 'john@example.com' },
+            { id: 2, name: 'Jane Smith', email: 'jane@example.com' }
+          ],
+          meta: { total: 2, page: 1 }
+        };
+
+      mockExecuteFunctions.getNodeParameter
+        .mockReturnValueOnce('getContacts') // operation
+        .mockReturnValueOnce('https://chat.example.com') // baseUrl
+        .mockReturnValueOnce('123') // accountId
+        .mockReturnValueOnce('test-api-token') // apiToken
+        .mockReturnValueOnce(2) // page
+        .mockReturnValueOnce(50); // perPage
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0]).toHaveLength(1);
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.operation).toBe('getContacts');
+        expect(result[0][0].json.contacts).toEqual(mockResponse.payload);
+        expect(result[0][0].json.meta).toEqual(mockResponse.meta);
+
+        // Verify API request structure
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+        expect(requestCall.method).toBe('GET');
+      expect(requestCall.url).toBe('https://chat.example.com/api/v1/accounts/123/contacts?page=2&per_page=50');
+        expect(requestCall.headers['api_access_token']).toBe('test-api-token');
+        expect(requestCall.headers['Content-Type']).toBe('application/json');
+      });
+
+      it('should handle contacts API failure', async () => {
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('getContacts')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('invalid-token');
+
+        mockExecuteFunctions.helpers.request.mockRejectedValue(new Error('Unauthorized'));
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(false);
+        expect(result[0][0].json.operation).toBe('getContacts');
+        expect(result[0][0].json.error).toBe('Unauthorized');
+      });
+    });
+
+    describe('Create Contact', () => {
+      it('should successfully create a new contact', async () => {
+        const contactData = {
+          name: 'New User',
+          email: 'newuser@example.com',
+          phone_number: '+1234567890'
+        };
+
+        const mockResponse = {
+          payload: { id: 3, ...contactData, created_at: '2024-01-01T00:00:00Z' }
+        };
+
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('createContact')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce(contactData); // contactData
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.operation).toBe('createContact');
+        expect(result[0][0].json.contact).toEqual(mockResponse.payload);
+
+        // Verify request body
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+        expect(requestCall.method).toBe('POST');
+        expect(requestCall.body).toEqual(contactData);
+      });
+
+      it('should handle contact creation failure', async () => {
+        const contactData = { email: 'invalid-email' };
+
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('createContact')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce(contactData);
+
+        mockExecuteFunctions.helpers.request.mockRejectedValue(new Error('Invalid email format'));
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(false);
+        expect(result[0][0].json.error).toBe('Invalid email format');
+        expect(result[0][0].json.contactData).toEqual(contactData);
+      });
+    });
+
+    describe('Get Contact', () => {
+      it('should retrieve specific contact by ID', async () => {
+        const mockResponse = {
+          payload: { id: 1, name: 'John Doe', email: 'john@example.com' }
+        };
+
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('getContact')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce('1'); // contactId
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.contact).toEqual(mockResponse.payload);
+
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+        expect(requestCall.url).toBe('https://chat.example.com/api/v1/accounts/123/contacts/1');
+      });
+
+      it('should handle contact not found', async () => {
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('getContact')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce('999');
+
+        mockExecuteFunctions.helpers.request.mockRejectedValue(new Error('Contact not found'));
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(false);
+        expect(result[0][0].json.error).toBe('Contact not found');
+        expect(result[0][0].json.contactId).toBe('999');
+      });
+    });
+
+    describe('Update Contact', () => {
+      it('should successfully update contact', async () => {
+        const updateData = { name: 'Updated Name', phone_number: '+9876543210' };
+        const mockResponse = {
+          payload: { id: 1, name: 'Updated Name', email: 'john@example.com', phone_number: '+9876543210' }
+        };
+
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('updateContact')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce('1') // contactId
+          .mockReturnValueOnce(updateData); // contactData
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.contact).toEqual(mockResponse.payload);
+
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+        expect(requestCall.method).toBe('PUT');
+        expect(requestCall.body).toEqual(updateData);
+      });
+    });
+
+    describe('Delete Contact', () => {
+      it('should successfully delete contact', async () => {
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('deleteContact')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce('1'); // contactId
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue({});
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.message).toBe('Contact deleted successfully');
+        expect(result[0][0].json.contactId).toBe('1');
+
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+        expect(requestCall.method).toBe('DELETE');
+      });
+    });
+  });
+
+  describe('Conversation Operations', () => {
+    describe('Get Conversations', () => {
+      it('should retrieve conversations for a contact', async () => {
+        const mockResponse = {
+          payload: [
+            { id: 1, status: 'open', messages_count: 5 },
+            { id: 2, status: 'resolved', messages_count: 3 }
+          ],
+          meta: { total: 2 }
+        };
+
+      mockExecuteFunctions.getNodeParameter
+        .mockReturnValueOnce('getConversations')
+        .mockReturnValueOnce('https://chat.example.com')
+        .mockReturnValueOnce('123')
+        .mockReturnValueOnce('test-api-token')
+        .mockReturnValueOnce(1) // page
+        .mockReturnValueOnce(25) // perPage
+        .mockReturnValueOnce('1'); // contactId
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.conversations).toEqual(mockResponse.payload);
+        expect(result[0][0].json.contactId).toBe('1');
+
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+      expect(requestCall.url).toBe('https://chat.example.com/api/v1/accounts/123/contacts/1/conversations?page=1&per_page=25');
+      });
+    });
+
+    describe('Update Conversation', () => {
+      it('should update conversation status and assignment', async () => {
+        const conversationData = {
+          status: 'resolved',
+          assignee_id: '5',
+          priority: 'high'
+        };
+
+        const mockResponse = {
+          payload: { id: 1, status: 'resolved', assignee_id: 5, priority: 'high' }
+        };
+
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('updateConversation')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce('1') // conversationId
+          .mockReturnValueOnce(conversationData); // conversationData
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.conversation).toEqual(mockResponse.payload);
+
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+        expect(requestCall.method).toBe('PUT');
+        expect(requestCall.body).toEqual(conversationData);
+        expect(requestCall.url).toBe('https://chat.example.com/api/v1/accounts/123/conversations/1');
+      });
+    });
+  });
+
+  describe('Message Operations', () => {
+    describe('Get Messages', () => {
+      it('should retrieve messages from conversation', async () => {
+        const mockResponse = {
+          payload: [
+            { id: 1, content: 'Hello!', message_type: 'incoming' },
+            { id: 2, content: 'Hi there!', message_type: 'outgoing' }
+          ],
+          meta: { total: 2 }
+        };
+
+      mockExecuteFunctions.getNodeParameter
+        .mockReturnValueOnce('getMessages')
+        .mockReturnValueOnce('https://chat.example.com')
+        .mockReturnValueOnce('123')
+        .mockReturnValueOnce('test-api-token')
+        .mockReturnValueOnce(3) // page
+        .mockReturnValueOnce(10) // perPage
+        .mockReturnValueOnce('1'); // conversationId
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.messages).toEqual(mockResponse.payload);
+        expect(result[0][0].json.conversationId).toBe('1');
+
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+      expect(requestCall.url).toBe('https://chat.example.com/api/v1/accounts/123/conversations/1/messages?page=3&per_page=10');
+      });
+    });
+
+    describe('Send Message', () => {
+      it('should send message to conversation', async () => {
+        const messageContent = 'This is a test message';
+        const mockResponse = {
+          id: 3,
+          content: messageContent,
+          message_type: 'outgoing',
+          created_at: '2024-01-01T00:00:00Z'
+        };
+
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('sendMessage')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce('1') // conversationId
+          .mockReturnValueOnce(messageContent); // messageContent
+
+        mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(true);
+        expect(result[0][0].json.message).toEqual(mockResponse);
+        expect(result[0][0].json.conversationId).toBe('1');
+
+        const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+        expect(requestCall.method).toBe('POST');
+        expect(requestCall.body.content).toBe(messageContent);
+        expect(requestCall.body.message_type).toBe('outgoing');
+        expect(requestCall.url).toBe('https://chat.example.com/api/v1/accounts/123/conversations/1/messages');
+      });
+
+      it('should handle message sending failure', async () => {
+        mockExecuteFunctions.getNodeParameter
+          .mockReturnValueOnce('sendMessage')
+          .mockReturnValueOnce('https://chat.example.com')
+          .mockReturnValueOnce('123')
+          .mockReturnValueOnce('test-api-token')
+          .mockReturnValueOnce('999') // invalid conversationId
+          .mockReturnValueOnce('Test message');
+
+        mockExecuteFunctions.helpers.request.mockRejectedValue(new Error('Conversation not found'));
+
+        const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+        expect(result[0][0].json.success).toBe(false);
+        expect(result[0][0].json.error).toBe('Conversation not found');
+        expect(result[0][0].json.conversationId).toBe('999');
+        expect(result[0][0].json.messageContent).toBe('Test message');
+      });
+    });
+  });
+
+  describe('Error Handling and Edge Cases', () => {
+    it('should handle unknown operation', async () => {
+      mockExecuteFunctions.getNodeParameter
+        .mockReturnValueOnce('unknownOperation')
+        .mockReturnValueOnce('https://chat.example.com')
+        .mockReturnValueOnce('123')
+        .mockReturnValueOnce('test-api-token');
+
+      let thrownError;
+      try {
+        await chatwoot.execute.call(mockExecuteFunctions);
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(thrownError.message).toBe('Unknown operation: unknownOperation');
+      expect(thrownError.name).toBe('NodeOperationError');
+    });
+
+    it('should handle continueOnFail mode', async () => {
+      mockExecuteFunctions.continueOnFail.mockReturnValue(true);
+      mockExecuteFunctions.getNodeParameter
+        .mockReturnValueOnce('getContacts')
+        .mockReturnValueOnce('https://invalid-url')
+        .mockReturnValueOnce('123')
+        .mockReturnValueOnce('test-api-token');
+
+      mockExecuteFunctions.helpers.request.mockRejectedValue(new Error('Network error'));
+
+      const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+      expect(result[0]).toHaveLength(1);
+      expect(result[0][0].json.success).toBe(false);
+      expect(result[0][0].json.error).toBe('Network error');
+    });
+
+    it('should include timestamp and operation in all responses', async () => {
+      const beforeTime = new Date().toISOString();
+
+      mockExecuteFunctions.getNodeParameter
+        .mockReturnValueOnce('getContacts')
+        .mockReturnValueOnce('https://chat.example.com')
+        .mockReturnValueOnce('123')
+        .mockReturnValueOnce('test-api-token');
+
+      mockExecuteFunctions.helpers.request.mockResolvedValue({ payload: [] });
+
+      const result = await chatwoot.execute.call(mockExecuteFunctions);
+      const afterTime = new Date().toISOString();
+
+      expect(result[0][0].json.timestamp).toBeDefined();
+      expect(result[0][0].json.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(result[0][0].json.timestamp >= beforeTime).toBe(true);
+      expect(result[0][0].json.timestamp <= afterTime).toBe(true);
+      expect(result[0][0].json.operation).toBe('getContacts');
+    });
+
+    it('should properly structure API authentication', async () => {
+      mockExecuteFunctions.getNodeParameter
+        .mockReturnValueOnce('getContacts')
+        .mockReturnValueOnce('https://enterprise.chatwoot.com')
+        .mockReturnValueOnce('enterprise-account-123')
+        .mockReturnValueOnce('secure-api-token-xyz');
+
+      mockExecuteFunctions.helpers.request.mockResolvedValue({ payload: [] });
+
+      await chatwoot.execute.call(mockExecuteFunctions);
+
+      const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+      expect(requestCall.headers['api_access_token']).toBe('secure-api-token-xyz');
+      expect(requestCall.headers['Content-Type']).toBe('application/json');
+      expect(requestCall.json).toBe(true);
+      expect(requestCall.url).toBe('https://enterprise.chatwoot.com/api/v1/accounts/enterprise-account-123/contacts');
+    });
+
+    it('should handle different contact data structures', async () => {
+      const complexContactData = {
+        name: 'Enterprise User',
+        email: 'enterprise@company.com',
+        phone_number: '+1-555-0123',
+        avatar_url: 'https://company.com/avatar.jpg',
+        identifier: 'EMP-12345',
+        custom_attributes: { department: 'Engineering', role: 'Senior Developer' }
+      };
+
+      const mockResponse = { payload: { id: 10, ...complexContactData } };
+
+      mockExecuteFunctions.getNodeParameter
+        .mockReturnValueOnce('createContact')
+        .mockReturnValueOnce('https://chat.example.com')
+        .mockReturnValueOnce('123')
+        .mockReturnValueOnce('test-api-token')
+        .mockReturnValueOnce(complexContactData);
+
+      mockExecuteFunctions.helpers.request.mockResolvedValue(mockResponse);
+
+      const result = await chatwoot.execute.call(mockExecuteFunctions);
+
+      expect(result[0][0].json.success).toBe(true);
+      expect(result[0][0].json.contact).toEqual(mockResponse.payload);
+
+      const requestCall = mockExecuteFunctions.helpers.request.mock.calls[0][0];
+      expect(requestCall.body).toEqual(complexContactData);
+    });
+  });
+});

--- a/nodes/Chatwoot/Chatwoot.node.ts
+++ b/nodes/Chatwoot/Chatwoot.node.ts
@@ -1,0 +1,520 @@
+import {
+  IExecuteFunctions,
+  INodeExecutionData,
+  INodeType,
+  INodeTypeDescription,
+  IHttpRequestMethods,
+  NodeOperationError,
+} from 'n8n-workflow';
+
+export class Chatwoot implements INodeType {
+  /**
+   * Create a standardized HTTP request to the Chatwoot API
+   * @param baseUrl - Chatwoot instance base URL
+   * @param accountId - Account ID
+   * @param apiToken - API access token
+   * @param endpoint - API endpoint (e.g., '/contacts')
+   * @param method - HTTP method
+   * @param body - Request body for POST/PUT requests
+   * @returns HTTP request options
+   */
+  public createApiRequest(
+    baseUrl: string, 
+    accountId: string, 
+    apiToken: string, 
+    endpoint: string, 
+    method: IHttpRequestMethods,
+    body?: any,
+    query?: Record<string, string | number | boolean | undefined>
+  ) {
+    let url = `${baseUrl}/api/v1/accounts/${accountId}${endpoint}`;
+    if (query && Object.keys(query).length > 0) {
+      const u = new URL(url);
+      const sp = new URLSearchParams(u.search);
+      for (const [k, v] of Object.entries(query)) {
+        if (v !== undefined && v !== null) sp.set(k, String(v));
+      }
+      u.search = sp.toString();
+      url = u.toString();
+    }
+    const options: any = {
+      method,
+      url,
+      headers: {
+        'api_access_token': apiToken,
+        'Content-Type': 'application/json',
+      },
+      json: true,
+    };
+    
+    if (body && (method === 'POST' || method === 'PUT')) {
+      options.body = body;
+    }
+    
+    return options;
+  }
+  
+  /**
+   * Execute API request with standardized error handling
+   * @param requestHelper - n8n request helper
+   * @param requestOptions - HTTP request options
+   * @param operation - Operation name for error context
+   * @param additionalData - Additional data to include in error response
+   * @returns Standardized API response
+   */
+  public async executeApiRequest(
+    requestHelper: any,
+    requestOptions: any,
+    operation: string,
+    additionalData: any = {}
+  ): Promise<{ success: boolean; [key: string]: any }> {
+    try {
+      const response = await requestHelper.request(requestOptions);
+      return {
+        operation,
+        success: true,
+        ...additionalData,
+        ...(response.payload ? { [this.getResponseKey(operation)]: response.payload } : (operation === 'sendMessage' ? { message: response } : {})),
+        ...(response.meta ? { meta: response.meta } : {}),
+      };
+    } catch (error) {
+      return {
+        operation,
+        success: false,
+        error: error instanceof Error ? error.message : `Failed to ${operation}`,
+        ...additionalData,
+      };
+    }
+  }
+  
+  /**
+   * Get the appropriate response key based on operation
+   * @param operation - Operation name
+   * @returns Response key name
+   */
+  public getResponseKey(operation: string): string {
+    const keyMap: { [key: string]: string } = {
+      'getContacts': 'contacts',
+      'createContact': 'contact',
+      'getContact': 'contact', 
+      'updateContact': 'contact',
+      'deleteContact': 'message',
+      'getConversations': 'conversations',
+      'updateConversation': 'conversation',
+      'getMessages': 'messages',
+      'sendMessage': 'message'
+    };
+    return keyMap[operation] || 'data';
+  }
+
+  description: INodeTypeDescription = {
+    displayName: 'Chatwoot',
+    name: 'chatwoot',
+    group: ['transform'],
+    version: 1,
+    description: 'Chatwoot integration for managing contacts, conversations, and messages',
+    defaults: {
+      name: 'Chatwoot',
+    },
+    inputs: [{ type: 'main' }],
+    outputs: [{ type: 'main' }],
+    properties: [
+      {
+        displayName: 'Operation',
+        name: 'operation',
+        type: 'options',
+        noDataExpression: false,
+        options: [
+          {
+            name: 'Get Contacts',
+            value: 'getContacts',
+            description: 'Retrieve all contacts',
+          },
+          {
+            name: 'Create Contact',
+            value: 'createContact',
+            description: 'Create a new contact',
+          },
+          {
+            name: 'Get Contact',
+            value: 'getContact',
+            description: 'Get a specific contact',
+          },
+          {
+            name: 'Update Contact',
+            value: 'updateContact',
+            description: 'Update a contact',
+          },
+          {
+            name: 'Delete Contact',
+            value: 'deleteContact',
+            description: 'Delete a contact',
+          },
+          {
+            name: 'Get Conversations',
+            value: 'getConversations',
+            description: 'Get conversations for a contact',
+          },
+          {
+            name: 'Get Messages',
+            value: 'getMessages',
+            description: 'Get messages from a conversation',
+          },
+          {
+            name: 'Send Message',
+            value: 'sendMessage',
+            description: 'Send a message to a conversation',
+          },
+          {
+            name: 'Update Conversation',
+            value: 'updateConversation',
+            description: 'Update conversation status or assignment',
+          },
+        ],
+        default: 'getContacts',
+        description: 'The operation to perform',
+      },
+      {
+        displayName: 'Page',
+        name: 'page',
+        type: 'number',
+        default: 1,
+        displayOptions: {
+          show: {
+            operation: ['getContacts', 'getConversations', 'getMessages'],
+          },
+        },
+        description: 'Page number for pagination',
+      },
+      {
+        displayName: 'Per Page',
+        name: 'perPage',
+        type: 'number',
+        default: 20,
+        displayOptions: {
+          show: {
+            operation: ['getContacts', 'getConversations', 'getMessages'],
+          },
+        },
+        description: 'Items per page',
+      },
+      {
+        displayName: 'Chatwoot Base URL',
+        name: 'baseUrl',
+        type: 'string',
+        default: 'https://your-chatwoot-instance.com',
+        required: true,
+        description: 'Chatwoot instance base URL',
+      },
+      {
+        displayName: 'Account ID',
+        name: 'accountId',
+        type: 'string',
+        default: '',
+        required: true,
+        description: 'Chatwoot account ID',
+      },
+      {
+        displayName: 'API Token',
+        name: 'apiToken',
+        type: 'string',
+        typeOptions: {
+          password: true,
+        },
+        default: '',
+        required: true,
+        description: 'Chatwoot API access token',
+      },
+      {
+        displayName: 'Contact ID',
+        name: 'contactId',
+        type: 'string',
+        default: '',
+        displayOptions: {
+          show: {
+            operation: ['getContact', 'updateContact', 'deleteContact', 'getConversations'],
+          },
+        },
+        description: 'Contact ID to work with',
+      },
+      {
+        displayName: 'Conversation ID',
+        name: 'conversationId',
+        type: 'string',
+        default: '',
+        displayOptions: {
+          show: {
+            operation: ['getMessages', 'sendMessage', 'updateConversation'],
+          },
+        },
+        description: 'Conversation ID to work with',
+      },
+      {
+        displayName: 'Message Content',
+        name: 'messageContent',
+        type: 'string',
+        typeOptions: {
+          rows: 3,
+        },
+        default: '',
+        displayOptions: {
+          show: {
+            operation: ['sendMessage'],
+          },
+        },
+        description: 'Content of the message to send',
+      },
+      {
+        displayName: 'Contact Data',
+        name: 'contactData',
+        type: 'collection',
+        placeholder: 'Add contact fields',
+        default: {},
+        displayOptions: {
+          show: {
+            operation: ['createContact', 'updateContact'],
+          },
+        },
+        options: [
+          {
+            displayName: 'Name',
+            name: 'name',
+            type: 'string',
+            default: '',
+            description: 'Contact name',
+          },
+          {
+            displayName: 'Email',
+            name: 'email',
+            type: 'string',
+            default: '',
+            description: 'Contact email address',
+          },
+          {
+            displayName: 'Phone Number',
+            name: 'phone_number',
+            type: 'string',
+            default: '',
+            description: 'Contact phone number',
+          },
+          {
+            displayName: 'Avatar URL',
+            name: 'avatar_url',
+            type: 'string',
+            default: '',
+            description: 'Contact avatar image URL',
+          },
+          {
+            displayName: 'Identifier',
+            name: 'identifier',
+            type: 'string',
+            default: '',
+            description: 'External identifier for the contact',
+          },
+          {
+            displayName: 'Custom Attributes',
+            name: 'custom_attributes',
+            type: 'json',
+            default: '{}',
+            description: 'Custom attributes as JSON object',
+          },
+        ],
+        description: 'Contact data fields',
+      },
+      {
+        displayName: 'Conversation Data',
+        name: 'conversationData',
+        type: 'collection',
+        placeholder: 'Add conversation fields',
+        default: {},
+        displayOptions: {
+          show: {
+            operation: ['updateConversation'],
+          },
+        },
+        options: [
+          {
+            displayName: 'Status',
+            name: 'status',
+            type: 'options',
+            options: [
+              {
+                name: 'Open',
+                value: 'open',
+              },
+              {
+                name: 'Resolved',
+                value: 'resolved',
+              },
+              {
+                name: 'Pending',
+                value: 'pending',
+              },
+            ],
+            default: 'open',
+            description: 'Conversation status',
+          },
+          {
+            displayName: 'Assignee ID',
+            name: 'assignee_id',
+            type: 'string',
+            default: '',
+            description: 'Agent ID to assign conversation to',
+          },
+          {
+            displayName: 'Team ID',
+            name: 'team_id',
+            type: 'string',
+            default: '',
+            description: 'Team ID to assign conversation to',
+          },
+          {
+            displayName: 'Priority',
+            name: 'priority',
+            type: 'options',
+            options: [
+              {
+                name: 'None',
+                value: 'none',
+              },
+              {
+                name: 'Low',
+                value: 'low',
+              },
+              {
+                name: 'Medium',
+                value: 'medium',
+              },
+              {
+                name: 'High',
+                value: 'high',
+              },
+              {
+                name: 'Urgent',
+                value: 'urgent',
+              },
+            ],
+            default: 'none',
+            description: 'Conversation priority',
+          },
+        ],
+        description: 'Conversation update data',
+      },
+    ],
+  };
+
+  async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+    const items = this.getInputData();
+    const returnData: INodeExecutionData[] = [];
+    const chatwootInstance = new Chatwoot();
+
+    for (let i = 0; i < items.length; i++) {
+      const operation = this.getNodeParameter('operation', i) as string;
+      const baseUrl = this.getNodeParameter('baseUrl', i) as string;
+      const accountId = this.getNodeParameter('accountId', i) as string;
+      const apiToken = this.getNodeParameter('apiToken', i) as string;
+
+      try {
+        let result: any = {};
+        
+        switch (operation) {
+          case 'getContacts':
+            const page = this.getNodeParameter('page', i) as number;
+            const perPage = this.getNodeParameter('perPage', i) as number;
+            const requestOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, '/contacts', 'GET', undefined, { page, per_page: perPage });
+            result = await chatwootInstance.executeApiRequest(this.helpers, requestOptions, 'getContacts');
+            break;
+            
+          case 'createContact':
+            const contactData = this.getNodeParameter('contactData', i) as any;
+            const createContactOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, '/contacts', 'POST', contactData);
+            result = await chatwootInstance.executeApiRequest(this.helpers, createContactOptions, 'createContact', { contactData });
+            break;
+            
+          case 'getContact':
+            const contactId = this.getNodeParameter('contactId', i) as string;
+            const getContactOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, `/contacts/${contactId}`, 'GET');
+            result = await chatwootInstance.executeApiRequest(this.helpers, getContactOptions, 'getContact', { contactId });
+            break;
+            
+          case 'sendMessage':
+            const conversationId = this.getNodeParameter('conversationId', i) as string;
+            const messageContent = this.getNodeParameter('messageContent', i) as string;
+            const messageBody = { content: messageContent, message_type: 'outgoing' };
+            const sendMessageOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, `/conversations/${conversationId}/messages`, 'POST', messageBody);
+            result = await chatwootInstance.executeApiRequest(this.helpers, sendMessageOptions, 'sendMessage', { conversationId, messageContent });
+            break;
+            
+          case 'updateContact':
+            const updateContactId = this.getNodeParameter('contactId', i) as string;
+            const updateContactData = this.getNodeParameter('contactData', i) as any;
+            const updateContactOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, `/contacts/${updateContactId}`, 'PUT', updateContactData);
+            result = await chatwootInstance.executeApiRequest(this.helpers, updateContactOptions, 'updateContact', { contactId: updateContactId, updateContactData });
+            break;
+            
+          case 'deleteContact':
+            const deleteContactId = this.getNodeParameter('contactId', i) as string;
+            const deleteContactOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, `/contacts/${deleteContactId}`, 'DELETE');
+            result = await chatwootInstance.executeApiRequest(this.helpers, deleteContactOptions, 'deleteContact', { contactId: deleteContactId, message: 'Contact deleted successfully' });
+            break;
+            
+          case 'getConversations':
+            const conversationsContactId = this.getNodeParameter('contactId', i) as string;
+            const pageConv = this.getNodeParameter('page', i) as number;
+            const perPageConv = this.getNodeParameter('perPage', i) as number;
+            const getConversationsOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, `/contacts/${conversationsContactId}/conversations`, 'GET', undefined, { page: pageConv, per_page: perPageConv });
+            result = await chatwootInstance.executeApiRequest(this.helpers, getConversationsOptions, 'getConversations', { contactId: conversationsContactId });
+            break;
+            
+          case 'getMessages':
+            const messagesConversationId = this.getNodeParameter('conversationId', i) as string;
+            const pageMsg = this.getNodeParameter('page', i) as number;
+            const perPageMsg = this.getNodeParameter('perPage', i) as number;
+            const getMessagesOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, `/conversations/${messagesConversationId}/messages`, 'GET', undefined, { page: pageMsg, per_page: perPageMsg });
+            result = await chatwootInstance.executeApiRequest(this.helpers, getMessagesOptions, 'getMessages', { conversationId: messagesConversationId });
+            break;
+            
+          case 'updateConversation':
+            const updateConversationId = this.getNodeParameter('conversationId', i) as string;
+            const conversationUpdateData = this.getNodeParameter('conversationData', i, {}) as any;
+            const updateConversationOptions = chatwootInstance.createApiRequest(baseUrl, accountId, apiToken, `/conversations/${updateConversationId}`, 'PUT', conversationUpdateData);
+            result = await chatwootInstance.executeApiRequest(this.helpers, updateConversationOptions, 'updateConversation', { conversationId: updateConversationId, conversationUpdateData });
+            break;
+            
+          default:
+            throw new NodeOperationError(this.getNode(), `Unknown operation: ${operation}`);
+        }
+
+        returnData.push({
+          json: {
+            operation,
+            timestamp: new Date().toISOString(),
+            success: !result.error,
+            ...result,
+          },
+        });
+        
+      } catch (error) {
+        if (this.continueOnFail()) {
+          returnData.push({
+            json: {
+              operation,
+              timestamp: new Date().toISOString(),
+              success: false,
+              error: error instanceof Error ? error.message : 'Unknown error',
+              item: i,
+            },
+          });
+        } else {
+          throw new NodeOperationError(
+            this.getNode(),
+            error instanceof Error ? error : new Error('Unknown error'),
+            { itemIndex: i }
+          );
+        }
+      }
+    }
+
+    return [returnData];
+  }
+}


### PR DESCRIPTION
- Add page/per_page node parameters for getContacts/getConversations/getMessages\n- Build query string in createApiRequest\n- Update tests to assert URLs with pagination